### PR TITLE
fix: Updated the getUploads method from old API to new API

### DIFF
--- a/src/lighthouseweb3/__init__.py
+++ b/src/lighthouseweb3/__init__.py
@@ -70,16 +70,15 @@ class Lighthouse:
             raise e
 
     @staticmethod
-    def getUploads(publicKey: str, pageNo: int = 1):
+    def getUploads(self, lastKey: int = None):
         """
         Get uploads from the Lighthouse.
 
-        :param publicKey: str, public key
-        :param pageNo: int, page number (default: 1)
+        :param lastKey: To navigate to different pages of results
         :return: List[t.DealData], list of deal data
         """
         try:
-            return getUploads.get_uploads(publicKey, pageNo)
+            return getUploads.get_uploads(self.token, lastKey)
         except Exception as e:
             raise e
 

--- a/src/lighthouseweb3/__init__.py
+++ b/src/lighthouseweb3/__init__.py
@@ -68,8 +68,7 @@ class Lighthouse:
             return deal_status.get_deal_status(cid)
         except Exception as e:
             raise e
-
-    @staticmethod
+    
     def getUploads(self, lastKey: int = None):
         """
         Get uploads from the Lighthouse.

--- a/src/lighthouseweb3/__init__.py
+++ b/src/lighthouseweb3/__init__.py
@@ -69,7 +69,7 @@ class Lighthouse:
         except Exception as e:
             raise e
     
-    def getUploads(self, lastKey: int = None):
+    def getUploads(self, lastKey: str = None):
         """
         Get uploads from the Lighthouse.
 

--- a/src/lighthouseweb3/functions/get_uploads.py
+++ b/src/lighthouseweb3/functions/get_uploads.py
@@ -11,7 +11,7 @@ def bytes_to_size(bytes_size):
     return f"{round(bytes_size, 2)} {units[index]}"
 
 
-def get_uploads(token: str, lastKey: int = None) :
+def get_uploads(token: str, lastKey: str = None) :
     headers = {
         "Authorization": f"Bearer {token}",
     }

--- a/src/lighthouseweb3/functions/get_uploads.py
+++ b/src/lighthouseweb3/functions/get_uploads.py
@@ -11,10 +11,14 @@ def bytes_to_size(bytes_size):
     return f"{round(bytes_size, 2)} {units[index]}"
 
 
-def get_uploads(publicKey: str, pageNo: int = 1) :
+def get_uploads(token: str, lastKey: int = None) :
+    headers = {
+        "Authorization": f"Bearer {token}",
+    }
+
     try:
-        url = f"{Config.lighthouse_api}/api/user/files_uploaded?publicKey={publicKey}&pageNo={pageNo}"
-        response = requests.get(url)
+        url = f"{Config.lighthouse_api}/api/user/files_uploaded?lastKey={lastKey}"
+        response = requests.get(url, headers=headers)
         response.raise_for_status()
         return response.json()
     except requests.HTTPError as error:

--- a/tests/test_deal_status.py
+++ b/tests/test_deal_status.py
@@ -15,7 +15,7 @@ class TestDealStatus(unittest.TestCase):
             "QmT9shXpKcn4HRbJhXJ1ZywzwjEo2QWbxAx4SVgW4eYKjG")
         self.assertIsInstance(res, list, "data is a list")
         self.assertIsInstance(res[0].get(
-            "dealId"), int, "dealId is Int")
+            "DealID"), int, "DealID is Int")
 
     def test_deal_status_init(self):
         """test deal_status function"""
@@ -25,4 +25,4 @@ class TestDealStatus(unittest.TestCase):
             "QmT9shXpKcn4HRbJhXJ1ZywzwjEo2QWbxAx4SVgW4eYKjG")
         self.assertIsInstance(res, list, "data is a list")
         self.assertIsInstance(res[0].get(
-            "dealId"), int, "dealId is Int")
+            "DealID"), int, "DealID is Int")

--- a/tests/test_get_uploads.py
+++ b/tests/test_get_uploads.py
@@ -7,18 +7,11 @@ from src.lighthouseweb3.functions.utils import NamedBufferedReader
 from .setup import parse_env
 
 
-class TestDealStatus(unittest.TestCase):
+class TestGetUploads(unittest.TestCase):
 
     def test_get_upload(self):
-        """test static test_get_upload function"""
-        res = Lighthouse.getUploads(
-            "0xB23809427cFc9B3346AEC5Bb70E7e574696cAF80")
-        self.assertIsInstance(res.get("fileList"), list, "data is a list")
-
-    def test_get_upload_init(self):
         """test get_upload function"""
         parse_env()
         l = Lighthouse(os.environ.get("LIGHTHOUSE_TOKEN"))
-        res = Lighthouse.getUploads(
-            "0xB23809427cFc9B3346AEC5Bb70E7e574696cAF80")
+        res = l.getUploads()
         self.assertIsInstance(res.get("fileList"), list, "data is a list")

--- a/tests/test_get_uploads.py
+++ b/tests/test_get_uploads.py
@@ -15,3 +15,12 @@ class TestGetUploads(unittest.TestCase):
         l = Lighthouse(os.environ.get("LIGHTHOUSE_TOKEN"))
         res = l.getUploads()
         self.assertIsInstance(res.get("fileList"), list, "data is a list")
+        self.assertIsInstance(res.get('totalFiles'), int, "totalFiles is an int")
+    
+    def test_get_upload_with_last_key(self):
+        """test get_upload function with lastKey"""
+        parse_env()
+        l = Lighthouse(os.environ.get("LIGHTHOUSE_TOKEN"))
+        res = l.getUploads('b5f60ba0-b708-41a3-b0f2-5c808ce63b48')
+        self.assertIsInstance(res.get("fileList"), list, "data is a list")
+        self.assertIsInstance(res.get('totalFiles'), int, "totalFiles is an int")

--- a/tests/test_get_uploads.py
+++ b/tests/test_get_uploads.py
@@ -24,3 +24,11 @@ class TestGetUploads(unittest.TestCase):
         res = l.getUploads('b5f60ba0-b708-41a3-b0f2-5c808ce63b48')
         self.assertIsInstance(res.get("fileList"), list, "data is a list")
         self.assertIsInstance(res.get('totalFiles'), int, "totalFiles is an int")
+    
+    def test_get_upload_with_invalid_token(self):
+        """test get_upload function with invalid token"""
+        parse_env()
+        l = Lighthouse("invalid_token")
+        with self.assertRaises(Exception) as context:
+            l.getUploads()
+            self.assertIn("authentication failed", str(context.exception).lower())


### PR DESCRIPTION
# What have you changed?
The `getUploads` method uses the old API call, so I changed it to the new API call

# Why have you changed it?
The old API is deprecated as per the docs

# How to test it
The `test_get_uploads.py` has two cases tested
1. The getUploads with lastKey as None
2. The getUploads with lastKey

```
pytest tests/test_get_uploads.py
```