### PR TITLE
feature: getFileInfo API added and tested successfully

### DIFF
--- a/src/lighthouseweb3/__init__.py
+++ b/src/lighthouseweb3/__init__.py
@@ -2,7 +2,13 @@
 
 import os
 import io
-from .functions import upload as d,deal_status, get_uploads as getUploads, download as _download
+from .functions import (
+    upload as d,
+    deal_status, 
+    get_uploads as getUploads, 
+    download as _download,
+    get_file_info as getFileInfo
+)
 
 
 class Lighthouse:
@@ -94,6 +100,19 @@ class Lighthouse:
         """
         try:
             return _download.get_file(cid)
+        except Exception as e:
+            raise e
+    
+    @staticmethod
+    def getFileInfo(cid: str):
+        """
+        Retrieves information about a file using its CID (Content Identifier).
+        :param cid: str, Content Identifier for the data to be downloaded
+        returns: dict, A dictionary containing file information.
+        """
+
+        try:
+            return getFileInfo.get_file_info(cid)
         except Exception as e:
             raise e
 

--- a/src/lighthouseweb3/functions/get_file_info.py
+++ b/src/lighthouseweb3/functions/get_file_info.py
@@ -1,0 +1,11 @@
+from .config import Config
+import requests as req
+
+def get_file_info(cid: str):
+  url = f"{Config.lighthouse_api}/api/lighthouse/file_info?cid={cid}"
+  try:
+    response = req.get(url)
+  except Exception as e:
+    raise Exception("Failed to get file metadata")
+
+  return response.json()

--- a/tests/test_get_file_info.py
+++ b/tests/test_get_file_info.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+import os
+import unittest
+from src.lighthouseweb3 import Lighthouse
+from .setup import parse_env
+
+
+class TestGetFileInfo(unittest.TestCase):
+
+    def test_get_file_info(self):
+        """test get_file_info function"""
+        parse_env()
+        l = Lighthouse(os.environ.get("LIGHTHOUSE_TOKEN"))
+        res = l.getFileInfo("Qmd5MBBScDUV3Ly8qahXtZFqyRRfYSmUwEcxpYcV4hzKfW")
+        self.assertIsInstance(res, dict, "data is a dict")
+        self.assertEqual(res.get("cid"),"Qmd5MBBScDUV3Ly8qahXtZFqyRRfYSmUwEcxpYcV4hzKfW", "cid is matching")

--- a/tests/test_get_file_info.py
+++ b/tests/test_get_file_info.py
@@ -14,3 +14,18 @@ class TestGetFileInfo(unittest.TestCase):
         res = l.getFileInfo("Qmd5MBBScDUV3Ly8qahXtZFqyRRfYSmUwEcxpYcV4hzKfW")
         self.assertIsInstance(res, dict, "data is a dict")
         self.assertEqual(res.get("cid"),"Qmd5MBBScDUV3Ly8qahXtZFqyRRfYSmUwEcxpYcV4hzKfW", "cid is matching")
+    
+    def test_get_file_info_invalid_token(self):
+        """test get_upload with invalid token"""
+        with self.assertRaises(Exception) as context:
+            l = Lighthouse("invalid_token")
+            l.getFileInfo("Qmd5MBBScDUV3Ly8qahXtZFqyRRfYSmUwEcxpYcV4hzKfW")
+            self.assertIn("authentication failed", str(context.exception).lower())
+    
+    def test_get_file_info_invalid_cid(self):
+        parse_env()
+        l = Lighthouse(os.environ.get("LIGHTHOUSE_TOKEN"))
+        res = l.getFileInfo("invalid_cid")
+        self.assertIsInstance(res, dict, "res is dict")
+        self.assertIsInstance(res.get('error'), dict, "error is dict")
+        self.assertEqual(res.get("error").get('message'), 'Not Found', 'cid not found')


### PR DESCRIPTION
# What have you changed
Added get file info API and tested

# Why have you changed
get file info API is missing

# How to test it
The test case is available in `test_get_file_info.py`
```
pytest tests/test_get_file_info.py
```