### PR TITLE
feature: getApiKey API added and tested successfully

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,5 @@ charset-normalizer==3.1.0
 idna==3.4
 requests==2.31.0
 urllib3==2.0.2
+web3
+eth-accounts

--- a/src/lighthouseweb3/__init__.py
+++ b/src/lighthouseweb3/__init__.py
@@ -2,7 +2,13 @@
 
 import os
 import io
-from .functions import upload as d,deal_status, get_uploads as getUploads, download as _download
+from .functions import (
+    upload as d,
+    deal_status, 
+    get_uploads as getUploads, 
+    download as _download,
+    get_api_key as getApiKey
+)
 
 
 class Lighthouse:
@@ -94,6 +100,22 @@ class Lighthouse:
         """
         try:
             return _download.get_file(cid)
+        except Exception as e:
+            raise e
+    
+    @staticmethod
+    def getApiKey(publicKey: str, signedMessage: str):
+        """
+        Generates and returns an API key for the given public key and signed message.
+
+        :param publicKey: str, The public key associated with the user.
+        :param signedMessage: str, The message signed by the user's private key.
+        :return: dict, A dict with generated API key.
+        """
+
+
+        try:
+            return getApiKey.get_api_key(publicKey, signedMessage)
         except Exception as e:
             raise e
 

--- a/src/lighthouseweb3/__init__.py
+++ b/src/lighthouseweb3/__init__.py
@@ -8,7 +8,8 @@ from .functions import (
     get_uploads as getUploads, 
     download as _download,
     get_file_info as getFileInfo,
-    get_balance as getBalance
+    get_balance as getBalance,
+    get_api_key as getApiKey
 )
 
 
@@ -123,6 +124,21 @@ class Lighthouse:
 
         try:
             return getFileInfo.get_file_info(cid)
+        except Exception as e:
+            raise e
+    
+    @staticmethod
+    def getApiKey(publicKey: str, signedMessage: str):
+        """
+        Generates and returns an API key for the given public key and signed message.
+        :param publicKey: str, The public key associated with the user.
+        :param signedMessage: str, The message signed by the user's private key.
+        :return: dict, A dict with generated API key.
+        """
+
+
+        try:
+            return getApiKey.get_api_key(publicKey, signedMessage)
         except Exception as e:
             raise e
 

--- a/src/lighthouseweb3/functions/get_api_key.py
+++ b/src/lighthouseweb3/functions/get_api_key.py
@@ -1,0 +1,28 @@
+from .config import Config
+import requests as req
+
+def get_api_key(publicKey: str, signedMessage: str):
+  url = f"{Config.lighthouse_api}/api/auth/create_api_key"
+
+  data = {
+    "publicKey": publicKey,
+    "signedMessage": signedMessage
+  }
+
+  try:
+    response = req.post(url, data=data)
+  except Exception as e:
+    raise Exception("Failed to create api key")
+
+  if response.status_code != 200:
+    return response.json()
+
+  apiKey = response.json()
+
+  result = {
+    "data": {
+      "apiKey" : apiKey
+    }
+  }
+
+  return result

--- a/tests/test_get_api_key.py
+++ b/tests/test_get_api_key.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+import os
+import unittest
+from src.lighthouseweb3 import Lighthouse
+from .setup import parse_env
+import requests as req
+from src.lighthouseweb3.functions.config import Config
+from web3 import Web3
+from eth_account.messages import encode_defunct
+
+
+class TestGetApiKey(unittest.TestCase):
+
+    def test_get_api_key(self):
+        """test getApiKey using valid signed message and public key"""
+        parse_env()
+        publicKey = os.environ.get("PUBLIC_KEY")
+        response = req.get(
+          f"{Config.lighthouse_api}/api/auth/get_auth_message?publicKey={publicKey}"
+        )
+
+        if(response.status_code != 200):
+            raise Exception("Failed to get authentication message")
+        
+        verificationMessage = response.json()
+
+        self.assertIn("Please prove you are the owner", verificationMessage, "Owner response should come")
+
+        encodedMessage = encode_defunct(text=verificationMessage)
+
+      
+        signedMessage = Web3().eth.account.sign_message(
+            encodedMessage, 
+            private_key=os.environ.get("PRIVATE_KEY")
+        ).signature.hex()
+
+        res = Lighthouse.getApiKey(publicKey, f"0x{signedMessage}")
+
+        self.assertIsInstance(res, dict, "res is a dict")
+        self.assertIsInstance(res.get("data"), dict, "data is a dict")
+        self.assertIsInstance(res.get('data').get('apiKey'), str, "apiKey is a string")
+    
+    def test_get_api_key_with_invalid_message(self):
+        """test getApiKey using signed invalid message and public key"""
+        parse_env()
+        publicKey = os.environ.get("PUBLIC_KEY")
+        encodedMessage = encode_defunct(text='random_message')
+
+      
+        signedMessage = Web3().eth.account.sign_message(
+            encodedMessage, 
+            private_key=os.environ.get("PRIVATE_KEY")
+        ).signature.hex()
+
+        res = Lighthouse.getApiKey(publicKey, f"0x{signedMessage}")
+        self.assertIsInstance(res, dict, "res is a dict")
+        self.assertIsInstance(res.get("error"), dict, "data is a dict")
+    
+    def test_get_api_key_with_random_private_key(self):
+        """test getApiKey using signed message with invalid private key and public key"""
+
+        parse_env()
+        publicKey = os.environ.get("PUBLIC_KEY")
+        response = req.get(
+          f"{Config.lighthouse_api}/api/auth/get_auth_message?publicKey={publicKey}"
+        )
+
+        if(response.status_code != 200):
+            raise Exception("Failed to get authentication message")
+        
+        verificationMessage = response.json()
+
+        self.assertIn("Please prove you are the owner", verificationMessage, "Owner response should come")
+
+        encodedMessage = encode_defunct(text=verificationMessage)
+
+      
+        signedMessage = Web3().eth.account.sign_message(
+            encodedMessage, 
+            private_key='0x8218aa5dbf4dbec243142286b93e26af521b3e91219583595a06a7765abc9c8b'
+        ).signature.hex()
+
+        res = Lighthouse.getApiKey(publicKey, f"0x{signedMessage}")
+
+        self.assertIsInstance(res, dict, "res is a dict")
+        self.assertIsInstance(res.get("error"), dict, "data is a dict")


### PR DESCRIPTION
# What have you changed
Added get api  key API and tested it.

# Why have you changed
get api key API is missing

# How to test it
The testcases are available in `test_get_api_key.py`. Make sure to add `PRIVATE_KEY` and `PUBLIC_KEY` in the `.env`
```
pytest tests/test_get_api_key.py
```