### PR TITLE
feature: create wallet API added and tested

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ charset-normalizer==3.1.0
 idna==3.4
 requests==2.31.0
 urllib3==2.0.2
+eth-account==0.13.7 

--- a/src/lighthouseweb3/__init__.py
+++ b/src/lighthouseweb3/__init__.py
@@ -2,7 +2,13 @@
 
 import os
 import io
-from .functions import upload as d,deal_status, get_uploads as getUploads, download as _download
+from .functions import ( 
+    upload as d,
+    deal_status, 
+    get_uploads as getUploads, 
+    download as _download,
+    create_wallet as createWallet
+)
 
 
 class Lighthouse:
@@ -39,6 +45,19 @@ class Lighthouse:
         except Exception as e:
             raise e
 
+    @staticmethod
+    def createWallet(password: str):
+        """
+        Creates a new wallet using the provided password.
+
+        :param password: str, The password to secure the wallet.
+        :return: dict, The wallet encrypted with the passowrd
+        """
+        try:
+            return createWallet.create_wallet(password)
+        except Exception as e:
+            raise e
+        
     @staticmethod
     def downloadBlob(dist: io.BufferedWriter, cid: str, chunk_size=1024*1024*10):
         """

--- a/src/lighthouseweb3/functions/create_wallet.py
+++ b/src/lighthouseweb3/functions/create_wallet.py
@@ -1,0 +1,23 @@
+import requests as req
+from .config import Config
+
+from eth_account import Account
+
+def create_wallet(password: str):
+  wallet = Account.create()
+
+  url = f"{Config.lighthouse_api}/api/auth/get_auth_message?publicKey={wallet.address}"
+
+  try:
+    response = req.get(url)
+  except Exception as e:
+    raise Exception("Failed to create wallet")
+
+  if response.status_code != 200:
+    return response.json()
+  
+  encrypted_wallet = wallet.encrypt(password)
+
+  del wallet
+
+  return encrypted_wallet

--- a/tests/test_create_wallet.py
+++ b/tests/test_create_wallet.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+import unittest
+from src.lighthouseweb3 import Lighthouse
+from eth_account import Account
+
+
+class TestCreateWallet(unittest.TestCase):
+
+    def test_create_wallet(self):
+        """test static create wallet function"""
+        password = 'TestPassword'
+        encrypted_wallet = Lighthouse.createWallet(password)
+        
+        private_key = Account.decrypt(encrypted_wallet, password)
+        wallet = Account.from_key(private_key)
+        self.assertEqual(wallet.address, f"0x{encrypted_wallet['address']}", 'Both public key must be same')
+    
+    def test_create_wallet_different_password(self):
+        """test static create wallet function use different password for decryption"""
+        encrypted_wallet = Lighthouse.createWallet('TestPassword')
+        with self.assertRaises(Exception) as context:
+          private_key = Account.decrypt(encrypted_wallet, 'RandomPassword')
+          self.assertIn("valueerror", str(context).lower())
+        


### PR DESCRIPTION
# What have I changed
Added create wallet API and tested. 

# Why have I changed
create wallet API is missing.

# How to test it
The test file is added in `test_create_wallet.py`
```
pytest tests/test_create_wallet.py
```
Make sure to install `eth-accounts` package. 

